### PR TITLE
Enable SSE 4.2

### DIFF
--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ GITHASH := $(shell git rev-parse --short HEAD)
 CFLAGS      = \
     -w                                  \
     -I src/libdvbcsa/dvbcsa             \
-    -msse2                              \
+    -msse2  -msse4.2                    \
     -O2                                 \
     -DGITHASH=\"$(GITHASH)\" 
 

--- a/src/aycwabtu_bs_algo.c
+++ b/src/aycwabtu_bs_algo.c
@@ -240,9 +240,7 @@ void aycw_extractbsdata(dvbcsa_bs_word_t* bs_data, unsigned char slice, unsigned
       tmp = 0;
       for (j = 0; j < 8; j++)
       {
-         dvbcsa_bs_word_t  bs_tmp, tmp2;
-
-         tmp2 = BS_SHR(bs_data[i * 8 + j], slice);
+         dvbcsa_bs_word_t  bs_tmp;
          tmp = tmp >> 1;
          bs_tmp = BS_AND(BS_SHR(bs_data[i * 8 + j], slice), BS_VAL_LSDW(1));
          tmp |= (uint8)BS_EXTLS32(BS_SHL(bs_tmp, 7));

--- a/src/aycwabtu_bs_block_ab.c
+++ b/src/aycwabtu_bs_block_ab.c
@@ -402,10 +402,10 @@ int aycw_checkPESheader(dvbcsa_bs_word_t *data, dvbcsa_bs_word_t *candidates)
 #if PARALLEL_MODE == PARALLEL_32_INT
    ret  = BS_EXTLS32(c);
 #elif PARALLEL_MODE == PARALLEL_128_SSE2
-   ret  = BS_EXTLS32(BS_SHR8(c, 0));
-   ret &= BS_EXTLS32(BS_SHR8(c, 4));
-   ret &= BS_EXTLS32(BS_SHR8(c, 8));
-   ret &= BS_EXTLS32(BS_SHR8(c, 12));
+	 ret  = BS_EXTRACT32(c,0);
+	 ret &= BS_EXTRACT32(c,1);
+	 ret &= BS_EXTRACT32(c,2);
+	 ret &= BS_EXTRACT32(c,3);
 #else
 #error wrong parallel mode
 #endif

--- a/src/aycwabtu_bs_sse2.c
+++ b/src/aycwabtu_bs_sse2.c
@@ -227,43 +227,6 @@ void aycw_bit2byteslice(dvbcsa_bs_word_t *data, int count)
 }
 #endif
 
-AYCW_INLINE __m128i BS_SHL(__m128i v, int n)
-{
-   __m128i v1, v2;
-
-   if ((n) >= 64)
-   {
-      v1 = _mm_slli_si128(v, 8);
-      v1 = _mm_slli_epi64(v1, (n)-64);
-   }
-   else
-   {
-      v1 = _mm_slli_epi64(v, n);
-      v2 = _mm_slli_si128(v, 8);
-      v2 = _mm_srli_epi64(v2, 64 - (n));
-      v1 = _mm_or_si128(v1, v2);
-   }
-   return v1;
-}
-
-AYCW_INLINE __m128i BS_SHR(__m128i v, int n)
-{
-   __m128i v1, v2;
-
-   if ((n) >= 64)
-   {
-      v1 = _mm_srli_si128(v, 8);
-      v1 = _mm_srli_epi64(v1, (n)-64);
-   }
-   else
-   {
-      v1 = _mm_srli_epi64(v, n);
-      v2 = _mm_srli_si128(v, 8);
-      v2 = _mm_slli_epi64(v2, 64 - (n));
-      v1 = _mm_or_si128(v1, v2);
-   }
-   return v1;
-}
 
 #endif
 

--- a/src/aycwabtu_bs_sse2.h
+++ b/src/aycwabtu_bs_sse2.h
@@ -11,8 +11,6 @@ typedef __m128i dvbcsa_bs_word_t;
 #define BS_BATCH_BYTES 16
 #define BS_BATCH_SHIFT  7
 
-//#define BS_SSE_X64
-
 #ifdef BS_SSE_X64
 #define BS_VAL(n, m)	_mm_set_epi64x(n, m)
 #define BS_VAL64(n)	BS_VAL(0x##n##ULL, 0x##n##ULL)
@@ -44,6 +42,19 @@ dvbcsa_bs_word_t BS_SHR(dvbcsa_bs_word_t v, int n);
 #define BS_EXTLS32(a)      _mm_cvtsi128_si32(a)       // Moves the least significant 32 bits of a to a 32-bit integer.
 
 #define BS_EMPTY()
+
+#ifdef __SSE4_2__
+
+#include <immintrin.h>
+#define BS_EXTRACT32(a,n)    _mm_extract_epi32(a,n)
+#define CHECK_ZERO(a) _mm_testz_si128((a),(a))
+
+#else
+
+#define BS_EXTRACT32(a,n)  BS_EXTLS32(BS_SHR8(c, (n*4)))
+#define CHECK_ZERO(a) (_mm_movemask_epi8(_mm_cmpeq_epi32((a),_mm_setzero_si128())) == 0xFFFF)
+
+#endif
 
 #endif
 


### PR DESCRIPTION
Enable SSE 4.2 and simplify BS_SHL/BS_SHR. The performance difference is 2% or less.